### PR TITLE
Fixed the clickable config and added a description to the manifest

### DIFF
--- a/clickable.json
+++ b/clickable.json
@@ -1,11 +1,5 @@
 {
-  "package": "plex.luksusdebug",
-  "app": "",
   "sdk": "ubuntu-sdk-15.04",
   "arch": "armhf",
-  "template": "pure",
-  "dir": "./build/",
-  "scripts": "",
-  "default": "",
-  "dependencies": ""
+  "template": "pure"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "plex-local.luksus",
-    "description": "",
+    "description": "Plex App for Ubuntu Touch",
     "architecture": "all",
     "title": "Plex",
     "hooks": {


### PR DESCRIPTION
This should allow you to publish in OpenStore without needing manual review.